### PR TITLE
docs: 前提技術スタックに React Testing Library を追加

### DIFF
--- a/docs/workflow/executable-spec-driven-workflow.md
+++ b/docs/workflow/executable-spec-driven-workflow.md
@@ -14,6 +14,7 @@
     - React※メタフレームワーク（Next.JS、React Router等）は関係ない
     - Storybook
     - Vitest
+    - React Testing Library
   - バックエンド
     - 指定なし
       - FastAPIのようにOpenAPI specを自動生成されるものだと楽


### PR DESCRIPTION
## やったこと

- issue #1 対応: `docs/workflow/executable-spec-driven-workflow.md` のフロント前提技術スタックに React Testing Library を追記
  - Storybook は仕様の可視化、React Testing Library は Presentational コンポーネントの振る舞いの自動検証として必要なため

## 結果

## 動作確認済み

- [ ] 